### PR TITLE
Gen exclude list

### DIFF
--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -72,7 +72,7 @@ df[df['ZIP_CONTENTS'].isna()] = ''
 
 print(df.head())
 print(df.tail())
-df = df.groupby('LOCAL_FOLDER').agg(','.join).reset_index()
+df = df.groupby('LOCAL_FOLDER').agg(','.join).reset_index().dropna()
 print(df.head())
 df.to_csv('test.csv', index=False)
 exit()

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -27,9 +27,11 @@ def list_all_uploaded_leaf_dirs(df,local_folder):
 
 def verify_zipped_dirs(zipped_dirs_df):
     unique_zipped_dirs = zipped_dirs_df['BASE_PATH'].unique()
+    print(len(unique_zipped_dirs))
     verified_zipped = []
     for u_z_d in unique_zipped_dirs:
         these_zipped_dirs = zipped_dirs_df.loc[zipped_dirs_df['BASE_PATH'] == u_z_d]
+        print(these_zipped_dirs)
         these_verified_zipped = []
         for t_z_d in these_zipped_dirs.iterrows():
             these_verified_zipped.extend(t_z_d[1]['ZIP_CONTENTS'].split(','))

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -94,9 +94,9 @@ df.to_csv('test.csv', index=False)
 # print(len(uploaded_dirs))
 j=0
 for folder_row in df.iterrows():
-    print(folder_row[1]['LOCAL_FOLDER'])
-    print(folder_row[1]['LOCAL_FILENAME'])
-    print(folder_row[1]['ZIP_CONTENTS'])
+    print(f"local_folder: {folder_row[1]['LOCAL_FOLDER']}")
+    print(f"local_filename: {folder_row[1]['LOCAL_FILENAME']}")
+    print(f"zip_contents: {folder_row[1]['ZIP_CONTENTS']}")
     j+=1
     if j>5:
         break

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -74,28 +74,33 @@ print(df.head())
 print(df.tail())
 df = df.groupby('LOCAL_FOLDER').agg(','.join).reset_index().dropna()
 print(df['LOCAL_FOLDER'].head())
-df.to_csv('test.csv')
-exit()
+df.to_csv('test.csv', index=False)
+
 # print(len(df))
 
 ### USE LOCAL_FILENAME NOT LOCAL_PATH
 
-print(sum(df['LOCAL_FILENAME'].str.endswith('.zip')))
+# print(sum(df['LOCAL_FILENAME'].str.endswith('.zip')))
 
-uploaded_dirs = list_all_uploaded_leaf_dirs(df)
+# uploaded_dirs = list_all_uploaded_leaf_dirs(df)
 
-print(len(uploaded_dirs))
+# print(len(uploaded_dirs))
 
-zipped_dirs_df = df[df['LOCAL_PATH'].str.endswith('.zip')]
-print(len(zipped_dirs_df))
-verify_zipped = verify_zipped_dirs(zipped_dirs_df)
-uploaded_dirs.extend(verify_zipped)
+# zipped_dirs_df = df[df['LOCAL_PATH'].str.endswith('.zip')]
+# print(len(zipped_dirs_df))
+# verify_zipped = verify_zipped_dirs(zipped_dirs_df)
+# uploaded_dirs.extend(verify_zipped)
 
-print(len(uploaded_dirs))
+# print(len(uploaded_dirs))
 
-with open('exclude_list.txt', 'w') as excl_f:
-    excl_f.write(str(uploaded_dirs))
-    excl_f.write('\n')
+for folder_row in df.iterrows():
+    print(folder_row[1]['LOCAL_FOLDER'])
+    print(folder_row[1]['LOCAL_FILENAME'])
+    print(folder_row[1]['ZIP_CONTENTS'])
+
+# with open('exclude_list.txt', 'w') as excl_f:
+#     excl_f.write(str(uploaded_dirs))
+#     excl_f.write('\n')
 
 # print('Local folder:', local_folder)
 # print('Local files:', local_files)

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -102,13 +102,13 @@ for folder_row in df.iterrows():
     logged_zipped_files = folder_row[1]['ZIP_CONTENTS'].split(',')
     local_folder = folder_row[1]['LOCAL_FOLDER']
     collated = False
-    if files[0].endswith('.zip') and zip_files[0] != '':
+    if logged_files[0].endswith('.zip') and logged_zipped_files[0] != '':
         collated = True
-    elif files[0].endswith('.zip') and zip_files[0] == '':
+    elif logged_files[0].endswith('.zip') and logged_zipped_files[0] == '':
         raise ValueError('Zip file with no contents')
-    elif files[0].endswith('.zip') == False and zip_files[0] != '':
+    elif logged_files[0].endswith('.zip') == False and logged_zipped_files[0] != '':
         raise ValueError('Non-zip file with zip contents')
-    elif files[0].endswith('.zip') == False and zip_files[0] == '':
+    elif logged_files[0].endswith('.zip') == False and logged_zipped_files[0] == '':
         collated = False
     
     if collated:

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -59,7 +59,7 @@ for row in df.iterrows():
     print(row[1]['LOCAL_PATH'])
     print(row[1]['LOCAL_FOLDER'])
     if row[1]['LOCAL_PATH'].startswith(row[1]['LOCAL_FOLDER']):
-        df.loc[row[1],'LOCAL_PATH'] = row[1]['LOCAL_PATH'][len(row[1]['LOCAL_FOLDER']):]
+        df.loc[row[1],'LOCAL_PATH'] = row[1]['LOCAL_PATH'].split('/')[-1]
 
 
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -63,7 +63,7 @@ for row in df.iterrows():
         local_fns.append(row[1]['LOCAL_PATH'][len(row[1]['LOCAL_FOLDER'])+1:])
     else:
         local_fns.append(row[1]['LOCAL_PATH'])
-df['LOCAL_FNS'] = local_fns
+df['LOCAL_FILENAME'] = local_fns
 df = df.drop(['LOCAL_PATH'], axis=1)
 
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -72,7 +72,7 @@ df = df.drop(['LOCAL_PATH'], axis=1)
 
 print(df.head())
 print(df.tail())
-print(df.groupby('LOCAL_FOLDER').apply(','.join))
+print(df.groupby('LOCAL_FOLDER').agg(','.join))
 exit()
 # print(len(df))
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -72,7 +72,7 @@ df = df.drop(['LOCAL_PATH'], axis=1)
 
 print(df.head())
 print(df.tail())
-print(df.groupby('LOCAL_FOLDER').sum())
+print(df.groupby('LOCAL_FOLDER').transform(lambda x: ','.join(x)).drop_duplicates())
 exit()
 # print(len(df))
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -115,7 +115,7 @@ for folder_row in df.iterrows():
         print(f'Folder: {local_folder}')
         print('Collated')
         print('Verifying files...')
-        files = [os.path.join(local_folder, f) for _,_,files in os.path.walk(local_folder) for f in files]
+        files = [os.path.join(local_folder, f) for _,_,files in os.walk(local_folder) for f in files]
         print(files)
         print(logged_zipped_files)
         

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -3,8 +3,9 @@ import os
 import sys
 import dask.dataframe as dd
 
-def list_all_uploaded_leaf_dirs(df,local_folder):
+def list_all_uploaded_leaf_dirs(df):
     all_uploaded_dirs = []
+    df.groupby('LOCAL_FOLDER').count()
     for root, dirs, files in os.walk(local_folder):
         print('.', end='', flush=True)
         if len(dirs) > 0:
@@ -13,7 +14,7 @@ def list_all_uploaded_leaf_dirs(df,local_folder):
         for filename in files:
             # if filename.endswith('.zip'): - zip files here are irrelevent. Zip files in the csv matter.
             #     continue
-            if os.path.join(root,filename) in df['LOCAL_PATH'].values:
+            if os.path.join(root,filename) in df['LOCAL_FILENAME'].values:
                 uploaded.append(True)
             else:
                 uploaded.append(False)
@@ -71,14 +72,15 @@ df = df.drop(['LOCAL_PATH'], axis=1)
 
 print(df.head())
 print(df.tail())
+print(df.groupby('LOCAL_FOLDER'))
 exit()
 # print(len(df))
 
 ### USE LOCAL_FILENAME NOT LOCAL_PATH
 
-print(sum(df['LOCAL_PATH'].str.endswith('.zip')))
+print(sum(df['LOCAL_FILENAME'].str.endswith('.zip')))
 
-uploaded_dirs = list_all_uploaded_leaf_dirs(df,local_folder)
+uploaded_dirs = list_all_uploaded_leaf_dirs(df)
 
 print(len(uploaded_dirs))
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -56,6 +56,8 @@ dtypes = {'LOCAL_FOLDER': 'str', 'LOCAL_PATH': 'str', 'FILE_SIZE': 'float', 'BUC
 df = dd.read_csv(csv_file, dtype=dtypes).drop(['FILE_SIZE','BUCKET_NAME','DESTINATION_KEY','CHECKSUM'], axis=1)
 local_folder_series = df['LOCAL_FOLDER'].compute()
 print(local_folder_series)
+for i in local_folder_series:
+    print(i)
 exit()
 local_folder = local_folder_series.iloc[0]
 print(local_folder)

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -72,7 +72,7 @@ df = df.drop(['LOCAL_PATH'], axis=1)
 
 print(df.head())
 print(df.tail())
-print(df.groupby('LOCAL_FOLDER'))
+print(df.groupby('LOCAL_FOLDER')).sum()
 exit()
 # print(len(df))
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -72,7 +72,8 @@ df[df['ZIP_CONTENTS'].isna()] = ''
 
 print(df.head())
 print(df.tail())
-print(df.groupby('LOCAL_FOLDER').agg(','.join)).reset_index()
+df = df.groupby('LOCAL_FOLDER').agg(','.join).reset_index()
+print(df.head())
 df.to_csv('test.csv', index=False)
 exit()
 # print(len(df))

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -92,11 +92,14 @@ df.to_csv('test.csv', index=False)
 # uploaded_dirs.extend(verify_zipped)
 
 # print(len(uploaded_dirs))
-
+j=0
 for folder_row in df.iterrows():
     print(folder_row[1]['LOCAL_FOLDER'])
     print(folder_row[1]['LOCAL_FILENAME'])
     print(folder_row[1]['ZIP_CONTENTS'])
+    j+=1
+    if j>5:
+        break
 
 # with open('exclude_list.txt', 'w') as excl_f:
 #     excl_f.write(str(uploaded_dirs))

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -101,6 +101,10 @@ for folder_row in df.iterrows():
                 total_files_len += len(files)
                 if all([f in files for f in logged_zipped_files]):
                     verified_content += 1
+            print(f'verified_content: {verified_content}')
+            print(f'total_files_len: {total_files_len}')
+            print(f'len(logged_zipped_files): {len(logged_zipped_files)}')
+            print(f'len(local_folders): {len(local_folders)}')
             if verified_content == len(local_folders) and total_files_len == len(logged_zipped_files):
                 print('Verified')
                 exclude_list.append(lf)

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -30,7 +30,9 @@ def verify_zipped_dirs(zipped_dirs_df):
     for u_z_d in unique_zipped_dirs:
         these_zipped_dirs = zipped_dirs_df.loc[zipped_dirs_df['BASE_PATH'] == u_z_d]
         verified_zipped = []
-        verified_zipped.extend(these_zipped_dirs['ZIP_CONTENTS'].values[0].split(','))
+        for t_z_d in these_zipped_dirs.iterrows():
+            verified_zipped.extend(t_z_d[1]['ZIP_CONTENTS'].split(','))
+        print(verified_zipped)
     print(verified_zipped)
     # return verified_zipped
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -78,13 +78,13 @@ for folder_row in df.iterrows():
         print('Collated')
         print('Verifying files...')
         for root, dirs, files in os.walk(local_folder):
-            print(root)
-            print(dirs)
-            print(files)
+            print('root',root)
+            print('dirs',dirs)
+            print('files',files)
         if local_folders == []:
             files = [f for _,_,files in os.walk(local_folder) for f in files]
-            print(files)
-            print(logged_zipped_files)
+            print('files',files)
+            print('logged_zipped_files',logged_zipped_files)
             if all([f in files for f in logged_zipped_files]) and len(files) == len(logged_zipped_files):
                 print('Verified')
                 exclude_list.append(local_folder)
@@ -94,8 +94,8 @@ for folder_row in df.iterrows():
             for lf in local_folders:
                 print(f'Verifying {lf}')
                 files = [f for _,_,files in os.walk(lf) for f in files]
-                print(files)
-                print(logged_zipped_files)
+                print('files',files)
+                print('logged_zipped_files',logged_zipped_files)
                 if all([f in files for f in logged_zipped_files]) and len(files) == len(logged_zipped_files):
                     print('Verified')
                     exclude_list.append(lf)

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -72,7 +72,7 @@ df = df.drop(['LOCAL_PATH'], axis=1)
 
 print(df.head())
 print(df.tail())
-print(df.groupby('LOCAL_FOLDER')).sum()
+print(df.groupby('LOCAL_FOLDER').sum())
 exit()
 # print(len(df))
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -52,11 +52,18 @@ for folder_row in df.iterrows():
     
     if collated:
         # extend_path = ''
+        subfolders = []
         for i, lzf in enumerate(logged_zipped_files):
             if '/' in lzf:
                 lzf_list = lzf.split('/')
                 logged_zipped_files[i] = lzf_list[-1]
+                subfolders.extend(lzf_list[:-1])
+        print(f"subfolders: {subfolders}")
+        print(f"number of unique subfolders: {len(set(subfolders))}")
                 # need different subfolder extensions and to veirfy at subfolder level
+                # make a set from the first element of the split list and check length
+                    # if length is 1, then extend_path = '/' + lzf_list[0]
+                    # if length is > 1, then change local_folder to list of local_folders
         #         extend_path = '/' + '/'.join(lzf_list[:-1])
         # local_folder += extend_path
         print(f'Folder: {local_folder}')
@@ -77,7 +84,7 @@ for folder_row in df.iterrows():
         
     else:
         print(f'Folder: {local_folder}')
-        print('Not collated')
+        print('Uncollated')
         print('Verifying files...')
         files = [f for _,_,files in os.walk(local_folder) for f in files]
         print(files)

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -32,7 +32,7 @@ def verify_zipped_dirs(zipped_dirs_df):
         verified_zipped = []
         for t_z_d in these_zipped_dirs.iterrows():
             verified_zipped.extend(t_z_d[1]['ZIP_CONTENTS'].split(','))
-        print(verified_zipped)
+        print(len(verified_zipped))
 
     # return verified_zipped
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -54,12 +54,18 @@ csv_file = sys.argv[1]
 #LOCAL_FOLDER,LOCAL_PATH,FILE_SIZE,BUCKET_NAME,DESTINATION_KEY,CHECKSUM,ZIP_CONTENTS
 dtypes = {'LOCAL_FOLDER': 'str', 'LOCAL_PATH': 'str', 'FILE_SIZE': 'float', 'BUCKET_NAME': 'str', 'DESTINATION_KEY': 'str', 'CHECKSUM': 'str', 'ZIP_CONTENTS': 'str'}
 df = dd.read_csv(csv_file, dtype=dtypes).drop(['FILE_SIZE','BUCKET_NAME','DESTINATION_KEY','CHECKSUM'], axis=1).compute()
-
+local_fns = []
 for row in df.iterrows():
     print(row[1]['LOCAL_PATH'])
     print(row[1]['LOCAL_FOLDER'])
+    
     if row[1]['LOCAL_PATH'].startswith(row[1]['LOCAL_FOLDER']):
-        df.loc[row[1]['LOCAL_PATH']] = row[1]['LOCAL_PATH'][len(row[1]['LOCAL_FOLDER'])+1:]
+        local_fns.append(row[1]['LOCAL_PATH'][len(row[1]['LOCAL_FOLDER'])+1:])
+    else:
+        local_fns.append(row[1]['LOCAL_PATH'])
+df['LOCAL_FNS'] = local_fns
+df = df.drop(['LOCAL_PATH'], axis=1)
+
 
 
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -96,7 +96,7 @@ j=0
 for folder_row in df.iterrows():
     logged_files = folder_row[1]['LOCAL_FILENAME'].split(',')
     logged_zipped_files = folder_row[1]['ZIP_CONTENTS'].split(',')
-    logged_zipped_files = [szf.split('/')[-1] for szf in logged_zipped_files]
+    # logged_zipped_files = [szf.split('/')[-1] for szf in logged_zipped_files]
     local_folder = folder_row[1]['LOCAL_FOLDER']
     collated = False
     if logged_files[0].endswith('.zip') and logged_zipped_files[0] != '':

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -4,7 +4,7 @@ import sys
 import dask.dataframe as dd
 
 csv_file = sys.argv[1]
-#LOCAL_FOLDER,LOCAL_PATH,FILE_SIZE,BUCKET_NAME,DESTINATION_KEY,CHECKSUM,ZIP_CONTENTS
+
 dtypes = {'LOCAL_FOLDER': 'str', 'LOCAL_PATH': 'str', 'FILE_SIZE': 'float', 'BUCKET_NAME': 'str', 'DESTINATION_KEY': 'str', 'CHECKSUM': 'str', 'ZIP_CONTENTS': 'str'}
 df = dd.read_csv(csv_file, dtype=dtypes).drop(['FILE_SIZE','BUCKET_NAME','DESTINATION_KEY','CHECKSUM'], axis=1).compute()
 local_fns = []
@@ -26,7 +26,7 @@ print(df.head())
 print(df.tail())
 df = df.groupby('LOCAL_FOLDER').agg(','.join).reset_index().dropna()
 print(df['LOCAL_FOLDER'].head())
-df.to_csv('test.csv', index=False)
+# df.to_csv('test.csv', index=False)
 
 
 j=0
@@ -47,8 +47,8 @@ for folder_row in df.iterrows():
         collated = False
 
     print(f"local_folder: {local_folder}")
-    print(f"logged_files: {logged_files}")
-    print(f"logged_zipped_files: {logged_zipped_files}")
+    # print(f"logged_files: {logged_files}")
+    # print(f"logged_zipped_files: {logged_zipped_files}")
     local_folders = []
     if collated:
         # extend_path = ''
@@ -58,7 +58,7 @@ for folder_row in df.iterrows():
                 lzf_list = lzf.split('/')
                 logged_zipped_files[i] = lzf_list[-1]
                 subfolders.extend(lzf_list[:-1])
-        print(f"subfolders: {subfolders}")
+        # print(f"subfolders: {subfolders}")
         print(f"number of unique subfolders: {len(set(subfolders))}")
         unique_subfolders = set(subfolders)
         if len(unique_subfolders) == 1:
@@ -67,24 +67,20 @@ for folder_row in df.iterrows():
         elif len(unique_subfolders) > 1:
             local_folders = [local_folder + '/' + subfolder for subfolder in unique_subfolders]
 
-          
-                # make a set from the first element of the split list and check length
-                    # if length is 1, then extend_path = '/' + lzf_list[0]
-                    # if length is > 1, then change local_folder to list of local_folders
         if local_folders == []:
             print(f'Local Folder: {local_folder}')
         else:
             print(f'Local Folders: {local_folders}')
         print('Collated')
         print('Verifying files...')
-        for root, dirs, files in os.walk(local_folder):
-            print('root',root)
-            print('dirs',dirs)
-            print('files',files)
+        # for root, dirs, files in os.walk(local_folder):
+            # print('root',root)
+            # print('dirs',dirs)
+            # print('files',files)
         if local_folders == []:
             files = [f for _,_,files in os.walk(local_folder) for f in files]
-            print('files',files)
-            print('logged_zipped_files',logged_zipped_files)
+            # print('files',files)
+            # print('logged_zipped_files',logged_zipped_files)
             if all([f in files for f in logged_zipped_files]) and len(files) == len(logged_zipped_files):
                 print('Verified')
                 exclude_list.append(local_folder)
@@ -96,18 +92,20 @@ for folder_row in df.iterrows():
             for lf in local_folders:
                 print(f'Verifying {lf}')
                 files = [f for _,_,files in os.walk(lf) for f in files]
-                print('files',files)
-                print('logged_zipped_files',logged_zipped_files)
+                # print('files',files)
+                # print('logged_zipped_files',logged_zipped_files)
                 total_files_len += len(files)
                 if all([f in logged_zipped_files for f in files]): # order important here as not expecting identical lists, just logged_zipped_files should contain all elements of files
                     verified_content += 1
-            print(f'verified_content: {verified_content}')
-            print(f'total_files_len: {total_files_len}')
-            print(f'len(logged_zipped_files): {len(logged_zipped_files)}')
-            print(f'len(local_folders): {len(local_folders)}')
+            # print(f'verified_content: {verified_content}')
+            # print(f'total_files_len: {total_files_len}')
+            # print(f'len(logged_zipped_files): {len(logged_zipped_files)}')
+            # print(f'len(local_folders): {len(local_folders)}')
             if verified_content == len(local_folders) and total_files_len == len(logged_zipped_files):
                 print('Verified')
                 exclude_list.append(lf)
+            else:
+                print('Unverified')
                
         
         
@@ -124,10 +122,6 @@ for folder_row in df.iterrows():
         else:
             print('Unverified')
 
-
-    j+=1
-    if j>5:
-        break
 print(exclude_list)
 with open('exclude_list.txt', 'w') as excl_f:
     excl_f.write(str(exclude_list))

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -51,43 +51,47 @@ for folder_row in df.iterrows():
     print(f"logged_zipped_files: {logged_zipped_files}")
     
     if collated:
-        extend_path = ''
-        for i, lzf in enumerate(logged_zipped_files):
-            if '/' in lzf:
-                lzf_list = lzf.split('/')
-                logged_zipped_files[i] = lzf_list[-1]
-                extend_path = '/' + '/'.join(lzf_list[:-1])
-        local_folder += extend_path
+        # extend_path = ''
+        # for i, lzf in enumerate(logged_zipped_files):
+        #     if '/' in lzf:
+        #         lzf_list = lzf.split('/')
+        #         logged_zipped_files[i] = lzf_list[-1]
+        #         extend_path = '/' + '/'.join(lzf_list[:-1])
+        # local_folder += extend_path
         print(f'Folder: {local_folder}')
         print('Collated')
         print('Verifying files...')
-        files = [f for _,_,files in os.walk(local_folder) for f in files]
-        print(files)
-        print(logged_zipped_files)
-        if all([f in files for f in logged_zipped_files]) and len(files) == len(logged_zipped_files):
-            print('Verified')
-            exclude_list.append(local_folder)
-        else:
-            print('Unverified')
+        for root, dirs, files in os.walk(local_folder):
+            print(root)
+            print(dirs)
+            print(files)
+#         files = [f for _,_,files in os.walk(local_folder) for f in files]
+#         print(files)
+#         print(logged_zipped_files)
+#         if all([f in files for f in logged_zipped_files]) and len(files) == len(logged_zipped_files):
+#             print('Verified')
+#             exclude_list.append(local_folder)
+#         else:
+#             print('Unverified')
         
-    else:
-        print(f'Folder: {local_folder}')
-        print('Not collated')
-        print('Verifying files...')
-        files = [f for _,_,files in os.walk(local_folder) for f in files]
-        print(files)
-        print(logged_files)
-        if all([f in files for f in logged_files]) and len(files) == len(logged_files):
-            print('Verified')
-            exclude_list.append(local_folder)
-        else:
-            print('Unverified')
+#     else:
+#         print(f'Folder: {local_folder}')
+#         print('Not collated')
+#         print('Verifying files...')
+#         files = [f for _,_,files in os.walk(local_folder) for f in files]
+#         print(files)
+#         print(logged_files)
+#         if all([f in files for f in logged_files]) and len(files) == len(logged_files):
+#             print('Verified')
+#             exclude_list.append(local_folder)
+#         else:
+#             print('Unverified')
 
 
-    j+=1
-    if j>5:
-        break
-print(exclude_list)
-with open('exclude_list.txt', 'w') as excl_f:
-    excl_f.write(str(exclude_list))
-    excl_f.write('\n')
+#     j+=1
+#     if j>5:
+#         break
+# print(exclude_list)
+# with open('exclude_list.txt', 'w') as excl_f:
+#     excl_f.write(str(exclude_list))
+#     excl_f.write('\n')

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -53,28 +53,16 @@ def verify_zipped_dirs(zipped_dirs_df):
 csv_file = sys.argv[1]
 #LOCAL_FOLDER,LOCAL_PATH,FILE_SIZE,BUCKET_NAME,DESTINATION_KEY,CHECKSUM,ZIP_CONTENTS
 dtypes = {'LOCAL_FOLDER': 'str', 'LOCAL_PATH': 'str', 'FILE_SIZE': 'float', 'BUCKET_NAME': 'str', 'DESTINATION_KEY': 'str', 'CHECKSUM': 'str', 'ZIP_CONTENTS': 'str'}
-df = dd.read_csv(csv_file, dtype=dtypes).drop(['FILE_SIZE','BUCKET_NAME','DESTINATION_KEY','CHECKSUM'], axis=1)
-local_folder_series = df['LOCAL_FOLDER'].compute()
-print(local_folder_series)
-for i in local_folder_series:
-    print(i)
-exit()
-local_folder = local_folder_series.iloc[0]
-print(local_folder)
-del local_folder_series
-df = df.drop(['LOCAL_FOLDER'], axis=1).compute()
-basepaths = []
-fnames = []
+df = dd.read_csv(csv_file, dtype=dtypes).drop(['FILE_SIZE','BUCKET_NAME','DESTINATION_KEY','CHECKSUM'], axis=1).compute()
+
 for row in df.iterrows():
-    basepaths.append('/'.join(row[1]['LOCAL_PATH'].split('/')[:-1]))
-    fnames.append(row[1]['LOCAL_PATH'].split('/')[-1])
-    # print(type(row[1]['ZIP_CONTENTS']) == str)
-df['BASE_PATH'] = basepaths
-df['FNAME'] = fnames
+    if row['LOCAL_PATH'].startswith(row['LOCAL_FOLDER']):
+        df.loc[row[0],'LOCAL_PATH'] = row['LOCAL_PATH'][len(row['LOCAL_FOLDER']):]
 
 
 
 print(df.head())
+exit()
 # print(len(df))
 
 print(sum(df['LOCAL_PATH'].str.endswith('.zip')))

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -97,6 +97,37 @@ for folder_row in df.iterrows():
     print(f"local_folder: {folder_row[1]['LOCAL_FOLDER']}")
     print(f"local_filename: {folder_row[1]['LOCAL_FILENAME']}")
     print(f"zip_contents: {folder_row[1]['ZIP_CONTENTS']}")
+
+    logged_files = folder_row[1]['LOCAL_FILENAME'].split(',')
+    logged_zipped_files = folder_row[1]['ZIP_CONTENTS'].split(',')
+    local_folder = folder_row[1]['LOCAL_FOLDER']
+    collated = False
+    if files[0].endswith('.zip') and zip_files[0] != '':
+        collated = True
+    elif files[0].endswith('.zip') and zip_files[0] == '':
+        raise ValueError('Zip file with no contents')
+    elif files[0].endswith('.zip') == False and zip_files[0] != '':
+        raise ValueError('Non-zip file with zip contents')
+    elif files[0].endswith('.zip') == False and zip_files[0] == '':
+        collated = False
+    
+    if collated:
+        print(f'Folder: {local_folder}')
+        print('Collated')
+        print('Verifying files...')
+        files = [os.path.join(local_folder, f) for _,_,files in os.path.walk(local_folder) for f in files]
+        print(files)
+        print(logged_zipped_files)
+        
+    else:
+        print(f'Folder: {local_folder}')
+        print('Not collated')
+        print('Verifying files...')
+        files = [os.path.join(local_folder, f) for _,_,files in os.path.walk(local_folder) for f in files]
+        print(files)
+        print(logged_files)
+
+
     j+=1
     if j>5:
         break

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -115,8 +115,9 @@ for folder_row in df.iterrows():
     if collated:
         for i, lzf in enumerate(logged_zipped_files):
             if '/' in lzf:
-                logged_zipped_files[i] = lzf.split('/')[-1]
-                local_folder += '/'.join(lzf.split('/')[:-1])
+                lzf_list = lzf.split('/')
+                logged_zipped_files[i] = lzf_list[-1]
+                local_folder += '/'.join(lzf_list[:-1])
         print(f'Folder: {local_folder}')
         print('Collated')
         print('Verifying files...')

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -71,7 +71,7 @@ for folder_row in df.iterrows():
                 # make a set from the first element of the split list and check length
                     # if length is 1, then extend_path = '/' + lzf_list[0]
                     # if length is > 1, then change local_folder to list of local_folders
-        if local_folders is []:
+        if local_folders == []:
             print(f'Local Folder: {local_folder}')
         else:
             print(f'Local Folders: {local_folders}')
@@ -81,7 +81,7 @@ for folder_row in df.iterrows():
             print(root)
             print(dirs)
             print(files)
-        if local_folders is []:
+        if local_folders == []:
             files = [f for _,_,files in os.walk(local_folder) for f in files]
             print(files)
             print(logged_zipped_files)

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -27,12 +27,24 @@ def list_all_uploaded_leaf_dirs(df,local_folder):
 
 def verify_zipped_dirs(zipped_dirs_df):
     unique_zipped_dirs = zipped_dirs_df['BASE_PATH'].unique()
+    verified_zipped = []
     for u_z_d in unique_zipped_dirs:
         these_zipped_dirs = zipped_dirs_df.loc[zipped_dirs_df['BASE_PATH'] == u_z_d]
-        verified_zipped = []
+        these_verified_zipped = []
         for t_z_d in these_zipped_dirs.iterrows():
-            verified_zipped.extend(t_z_d[1]['ZIP_CONTENTS'].split(','))
-        print(len(verified_zipped))
+            these_verified_zipped.extend(t_z_d[1]['ZIP_CONTENTS'].split(','))
+        files_in_basepath = [ f for _, _, files in os.walk(u_z_d) for f in files ]
+        verified = []
+        for f_in_b in files_in_basepath:
+            if f_in_b in these_verified_zipped:
+                verified.append(True)
+            else:
+                verified.append(False)
+        if all(verified):
+            print(f'All files in {u_z_d} have been uploaded - adding to exclude list.')
+            verified_zipped.append(u_z_d)
+            print(f'Current exclude list length: {len(verified_zipped)}')
+    print(len(verified_zipped))
 
     # return verified_zipped
 
@@ -63,7 +75,12 @@ print(sum(df['LOCAL_PATH'].str.endswith('.zip')))
 
 uploaded_dirs = list_all_uploaded_leaf_dirs(df,local_folder)
 zipped_dirs_df = df[df['LOCAL_PATH'].str.endswith('.zip')]
+
+
+print(len(uploaded_dirs))
+
 verify_zipped = verify_zipped_dirs(zipped_dirs_df)
+uploaded_dirs.extend(verify_zipped)
 
 print(len(uploaded_dirs))
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -26,7 +26,7 @@ def list_all_uploaded_leaf_dirs(df,local_folder):
     return all_uploaded_dirs
 
 def verify_zipped_dirs(zipped_dirs_df):
-    unique_zipped_dirs = zipped_dirs_df['BASE_PATH']#.unique()
+    unique_zipped_dirs = zipped_dirs_df['BASE_PATH'].unique()
     print(unique_zipped_dirs)
     verified_zipped = []
     for u_z_d in unique_zipped_dirs:
@@ -55,6 +55,8 @@ csv_file = sys.argv[1]
 dtypes = {'LOCAL_FOLDER': 'str', 'LOCAL_PATH': 'str', 'FILE_SIZE': 'float', 'BUCKET_NAME': 'str', 'DESTINATION_KEY': 'str', 'CHECKSUM': 'str', 'ZIP_CONTENTS': 'str'}
 df = dd.read_csv(csv_file, dtype=dtypes).drop(['FILE_SIZE','BUCKET_NAME','DESTINATION_KEY','CHECKSUM'], axis=1)
 local_folder_series = df['LOCAL_FOLDER'].compute()
+print(local_folder_series)
+exit()
 local_folder = local_folder_series.iloc[0]
 print(local_folder)
 del local_folder_series

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -66,13 +66,13 @@ for row in df.iterrows():
         local_fns.append(row[1]['LOCAL_PATH'])
 df['LOCAL_FILENAME'] = local_fns
 df = df.drop(['LOCAL_PATH'], axis=1)
-
+df[df['ZIP_CONTENTS'].isna()] = ''
 
 
 
 print(df.head())
 print(df.tail())
-print(df.groupby('LOCAL_FOLDER')['ZIP_CONTENTS','LOCAL_FILENAME'].agg(','.join))
+print(df.groupby('LOCAL_FOLDER').agg(','.join))
 exit()
 # print(len(df))
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -113,11 +113,13 @@ for folder_row in df.iterrows():
     print(f"logged_zipped_files: {logged_zipped_files}")
     
     if collated:
+        extend_path = ''
         for i, lzf in enumerate(logged_zipped_files):
             if '/' in lzf:
                 lzf_list = lzf.split('/')
                 logged_zipped_files[i] = lzf_list[-1]
-                local_folder += '/'.join(lzf_list[:-1])
+                extend_path = '/' + '/'.join(lzf_list[:-1])
+        local_folder += extend_path
         print(f'Folder: {local_folder}')
         print('Collated')
         print('Verifying files...')

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -33,7 +33,7 @@ def verify_zipped_dirs(zipped_dirs_df):
         for t_z_d in these_zipped_dirs.iterrows():
             verified_zipped.extend(t_z_d[1]['ZIP_CONTENTS'].split(','))
         print(verified_zipped)
-    print(verified_zipped)
+
     # return verified_zipped
 
 csv_file = sys.argv[1]

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -49,7 +49,7 @@ for folder_row in df.iterrows():
     print(f"local_folder: {local_folder}")
     print(f"logged_files: {logged_files}")
     print(f"logged_zipped_files: {logged_zipped_files}")
-    
+    local_folders = []
     if collated:
         # extend_path = ''
         subfolders = []
@@ -60,27 +60,48 @@ for folder_row in df.iterrows():
                 subfolders.extend(lzf_list[:-1])
         print(f"subfolders: {subfolders}")
         print(f"number of unique subfolders: {len(set(subfolders))}")
-                # need different subfolder extensions and to veirfy at subfolder level
+        unique_subfolders = set(subfolders)
+        if len(unique_subfolders) == 1:
+            extend_path = '/' + subfolders[0]
+            local_folder += extend_path
+        elif len(unique_subfolders) > 1:
+            local_folders = [local_folder + '/' + subfolder for subfolder in unique_subfolders]
+
+          
                 # make a set from the first element of the split list and check length
                     # if length is 1, then extend_path = '/' + lzf_list[0]
                     # if length is > 1, then change local_folder to list of local_folders
-        #         extend_path = '/' + '/'.join(lzf_list[:-1])
-        # local_folder += extend_path
-        print(f'Folder: {local_folder}')
+        if local_folders is []:
+            print(f'Local Folder: {local_folder}')
+        else:
+            print(f'Local Folders: {local_folders}')
         print('Collated')
         print('Verifying files...')
         for root, dirs, files in os.walk(local_folder):
             print(root)
             print(dirs)
             print(files)
-        files = [f for _,_,files in os.walk(local_folder) for f in files]
-        print(files)
-        print(logged_zipped_files)
-        if all([f in files for f in logged_zipped_files]) and len(files) == len(logged_zipped_files):
-            print('Verified')
-            exclude_list.append(local_folder)
+        if local_folders is []:
+            files = [f for _,_,files in os.walk(local_folder) for f in files]
+            print(files)
+            print(logged_zipped_files)
+            if all([f in files for f in logged_zipped_files]) and len(files) == len(logged_zipped_files):
+                print('Verified')
+                exclude_list.append(local_folder)
+            else:
+                print('Unverified')
         else:
-            print('Unverified')
+            for lf in local_folders:
+                print(f'Verifying {lf}')
+                files = [f for _,_,files in os.walk(lf) for f in files]
+                print(files)
+                print(logged_zipped_files)
+                if all([f in files for f in logged_zipped_files]) and len(files) == len(logged_zipped_files):
+                    print('Verified')
+                    exclude_list.append(lf)
+                else:
+                    print('Unverified')
+        
         
     else:
         print(f'Folder: {local_folder}')

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -72,7 +72,7 @@ df = df.drop(['LOCAL_PATH'], axis=1)
 
 print(df.head())
 print(df.tail())
-print(df.groupby('LOCAL_FOLDER').agg(','.join))
+print(df.groupby('LOCAL_FOLDER')['ZIP_CONTENTS','LOCAL_FILENAME'].agg(','.join))
 exit()
 # print(len(df))
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -73,8 +73,8 @@ df[df['ZIP_CONTENTS'].isna()] = ''
 print(df.head())
 print(df.tail())
 df = df.groupby('LOCAL_FOLDER').agg(','.join).reset_index().dropna()
-print(df.head())
-df.to_csv('test.csv', index=False)
+print(df['LOCAL_FOLDER'].head())
+df.to_csv('test.csv')
 exit()
 # print(len(df))
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -72,7 +72,7 @@ df = df.drop(['LOCAL_PATH'], axis=1)
 
 print(df.head())
 print(df.tail())
-print(df.groupby('LOCAL_FOLDER').transform(lambda x: ','.join(x)).drop_duplicates())
+print(df.groupby('LOCAL_FOLDER').transform(lambda x: ','.join(str(x))).drop_duplicates())
 exit()
 # print(len(df))
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -57,7 +57,7 @@ df = dd.read_csv(csv_file, dtype=dtypes).drop(['FILE_SIZE','BUCKET_NAME','DESTIN
 
 for row in df.iterrows():
     if row['LOCAL_PATH'].startswith(row['LOCAL_FOLDER']):
-        df.loc[row[0],'LOCAL_PATH'] = row['LOCAL_PATH'][len(row['LOCAL_FOLDER']):]
+        df.loc[row[1],'LOCAL_PATH'] = row[1]['LOCAL_PATH'][len(row[1]['LOCAL_FOLDER']):]
 
 
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -72,7 +72,8 @@ df[df['ZIP_CONTENTS'].isna()] = ''
 
 print(df.head())
 print(df.tail())
-print(df.groupby('LOCAL_FOLDER').agg(','.join))
+print(df.groupby('LOCAL_FOLDER').agg(','.join)).reset_index()
+df.to_csv('test.csv', index=False)
 exit()
 # print(len(df))
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -100,6 +100,7 @@ for folder_row in df.iterrows():
 
     logged_files = folder_row[1]['LOCAL_FILENAME'].split(',')
     logged_zipped_files = folder_row[1]['ZIP_CONTENTS'].split(',')
+    logged_zipped_files = [szf.split('/')[-1] for szf in logged_zipped_files]
     local_folder = folder_row[1]['LOCAL_FOLDER']
     collated = False
     if logged_files[0].endswith('.zip') and logged_zipped_files[0] != '':
@@ -115,17 +116,21 @@ for folder_row in df.iterrows():
         print(f'Folder: {local_folder}')
         print('Collated')
         print('Verifying files...')
-        files = [os.path.join(local_folder, f) for _,_,files in os.walk(local_folder) for f in files]
+        files = [f for _,_,files in os.walk(local_folder) for f in files]
         print(files)
         print(logged_zipped_files)
+        if all([f in files for f in logged_zipped_files]):
+            print('All files uploaded')
         
     else:
         print(f'Folder: {local_folder}')
         print('Not collated')
         print('Verifying files...')
-        files = [os.path.join(local_folder, f) for _,_,files in os.walk(local_folder) for f in files]
+        files = [f for _,_,files in os.walk(local_folder) for f in files]
         print(files)
         print(logged_files)
+        if all([f in files for f in logged_files]):
+            print('All files uploaded')
 
 
     j+=1

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -99,7 +99,7 @@ for folder_row in df.iterrows():
                 print('files',files)
                 print('logged_zipped_files',logged_zipped_files)
                 total_files_len += len(files)
-                if all([f in files for f in logged_zipped_files]):
+                if all([f in logged_zipped_files for f in files]): # order important here as not expecting identical lists, just logged_zipped_files should contain all elements of files
                     verified_content += 1
             print(f'verified_content: {verified_content}')
             print(f'total_files_len: {total_files_len}')

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -52,10 +52,10 @@ for folder_row in df.iterrows():
     
     if collated:
         # extend_path = ''
-        # for i, lzf in enumerate(logged_zipped_files):
-        #     if '/' in lzf:
-        #         lzf_list = lzf.split('/')
-        #         logged_zipped_files[i] = lzf_list[-1]
+        for i, lzf in enumerate(logged_zipped_files):
+            if '/' in lzf:
+                lzf_list = lzf.split('/')
+                logged_zipped_files[i] = lzf_list[-1]
         #         extend_path = '/' + '/'.join(lzf_list[:-1])
         # local_folder += extend_path
         print(f'Folder: {local_folder}')
@@ -65,33 +65,33 @@ for folder_row in df.iterrows():
             print(root)
             print(dirs)
             print(files)
-#         files = [f for _,_,files in os.walk(local_folder) for f in files]
-#         print(files)
-#         print(logged_zipped_files)
-#         if all([f in files for f in logged_zipped_files]) and len(files) == len(logged_zipped_files):
-#             print('Verified')
-#             exclude_list.append(local_folder)
-#         else:
-#             print('Unverified')
+        files = [f for _,_,files in os.walk(local_folder) for f in files]
+        print(files)
+        print(logged_zipped_files)
+        if all([f in files for f in logged_zipped_files]) and len(files) == len(logged_zipped_files):
+            print('Verified')
+            exclude_list.append(local_folder)
+        else:
+            print('Unverified')
         
-#     else:
-#         print(f'Folder: {local_folder}')
-#         print('Not collated')
-#         print('Verifying files...')
-#         files = [f for _,_,files in os.walk(local_folder) for f in files]
-#         print(files)
-#         print(logged_files)
-#         if all([f in files for f in logged_files]) and len(files) == len(logged_files):
-#             print('Verified')
-#             exclude_list.append(local_folder)
-#         else:
-#             print('Unverified')
+    else:
+        print(f'Folder: {local_folder}')
+        print('Not collated')
+        print('Verifying files...')
+        files = [f for _,_,files in os.walk(local_folder) for f in files]
+        print(files)
+        print(logged_files)
+        if all([f in files for f in logged_files]) and len(files) == len(logged_files):
+            print('Verified')
+            exclude_list.append(local_folder)
+        else:
+            print('Unverified')
 
 
-#     j+=1
-#     if j>5:
-#         break
-# print(exclude_list)
-# with open('exclude_list.txt', 'w') as excl_f:
-#     excl_f.write(str(exclude_list))
-#     excl_f.write('\n')
+    j+=1
+    if j>5:
+        break
+print(exclude_list)
+with open('exclude_list.txt', 'w') as excl_f:
+    excl_f.write(str(exclude_list))
+    excl_f.write('\n')

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -62,23 +62,23 @@ fnames = []
 for row in df.iterrows():
     basepaths.append('/'.join(row[1]['LOCAL_PATH'].split('/')[:-1]))
     fnames.append(row[1]['LOCAL_PATH'].split('/')[-1])
-    print(type(row[1]['ZIP_CONTENTS']) == str)
+    # print(type(row[1]['ZIP_CONTENTS']) == str)
 df['BASE_PATH'] = basepaths
 df['FNAME'] = fnames
 
 
 
 print(df.head())
-print(len(df))
+# print(len(df))
 
 print(sum(df['LOCAL_PATH'].str.endswith('.zip')))
 
 uploaded_dirs = list_all_uploaded_leaf_dirs(df,local_folder)
-zipped_dirs_df = df[df['LOCAL_PATH'].str.endswith('.zip')]
-
 
 print(len(uploaded_dirs))
 
+zipped_dirs_df = df[df['LOCAL_PATH'].str.endswith('.zip')]
+print(len(zipped_dirs_df))
 verify_zipped = verify_zipped_dirs(zipped_dirs_df)
 uploaded_dirs.extend(verify_zipped)
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -59,7 +59,7 @@ for row in df.iterrows():
     print(row[1]['LOCAL_PATH'])
     print(row[1]['LOCAL_FOLDER'])
     if row[1]['LOCAL_PATH'].startswith(row[1]['LOCAL_FOLDER']):
-        df.loc[row[1]['LOCAL_PATH']] = row[1]['LOCAL_PATH'].split('/')[-1]
+        df.loc[row[1]['LOCAL_PATH']] = row[1]['LOCAL_PATH'][len(row[1]['LOCAL_FOLDER'])+1:]
 
 
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -74,6 +74,8 @@ print(df.tail())
 exit()
 # print(len(df))
 
+### USE LOCAL_FILENAME NOT LOCAL_PATH
+
 print(sum(df['LOCAL_PATH'].str.endswith('.zip')))
 
 uploaded_dirs = list_all_uploaded_leaf_dirs(df,local_folder)

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -124,7 +124,9 @@ for folder_row in df.iterrows():
         print(files)
         print(logged_zipped_files)
         if all([f in files for f in logged_zipped_files]) and len(files) == len(logged_zipped_files):
-            print('All files uploaded')
+            print('Verified')
+        else:
+            print('Unverified')
         
     else:
         print(f'Folder: {local_folder}')
@@ -134,7 +136,9 @@ for folder_row in df.iterrows():
         print(files)
         print(logged_files)
         if all([f in files for f in logged_files]) and len(files) == len(logged_files):
-            print('All files uploaded')
+            print('Verified')
+        else:
+            print('Unverified')
 
 
     j+=1

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -30,7 +30,7 @@ def verify_zipped_dirs(zipped_dirs_df):
     for u_z_d in unique_zipped_dirs:
         these_zipped_dirs = zipped_dirs_df.loc[zipped_dirs_df['BASE_PATH'] == u_z_d]
         verified_zipped = []
-        verified_zipped.extend(these_zipped_dirs['ZIP_CONTENTS'].values.split(','))
+        verified_zipped.extend(these_zipped_dirs['ZIP_CONTENTS'].values[0].split(','))
     print(verified_zipped)
     # return verified_zipped
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -59,7 +59,7 @@ for row in df.iterrows():
     print(row[1]['LOCAL_PATH'])
     print(row[1]['LOCAL_FOLDER'])
     if row[1]['LOCAL_PATH'].startswith(row[1]['LOCAL_FOLDER']):
-        df.loc[row[1],'LOCAL_PATH'] = row[1]['LOCAL_PATH'].split('/')[-1]
+        df.loc[row[1]['LOCAL_PATH']] = row[1]['LOCAL_PATH'].split('/')[-1]
 
 
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -26,7 +26,7 @@ def list_all_uploaded_leaf_dirs(df,local_folder):
     return all_uploaded_dirs
 
 def verify_zipped_dirs(zipped_dirs_df):
-    unique_zipped_dirs = zipped_dirs_df['BASE_PATH'].unique()
+    unique_zipped_dirs = zipped_dirs_df['BASE_PATH']#.unique()
     print(unique_zipped_dirs)
     verified_zipped = []
     for u_z_d in unique_zipped_dirs:

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -70,6 +70,7 @@ df = df.drop(['LOCAL_PATH'], axis=1)
 
 
 print(df.head())
+print(df.tail())
 exit()
 # print(len(df))
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -101,10 +101,6 @@ for folder_row in df.iterrows():
     collated = False
     if logged_files[0].endswith('.zip') and logged_zipped_files[0] != '':
         collated = True
-        for i, lzf in enumerate(logged_zipped_files):
-            if '/' in lzf:
-                logged_zipped_files[i] = lzf.split('/')[-1]
-                local_folder += '/'.join(lzf.split('/')[:-1])
     elif logged_files[0].endswith('.zip') and logged_zipped_files[0] == '':
         raise ValueError('Zip file with no contents')
     elif logged_files[0].endswith('.zip') == False and logged_zipped_files[0] != '':
@@ -117,13 +113,17 @@ for folder_row in df.iterrows():
     print(f"logged_zipped_files: {logged_zipped_files}")
     
     if collated:
+        for i, lzf in enumerate(logged_zipped_files):
+            if '/' in lzf:
+                logged_zipped_files[i] = lzf.split('/')[-1]
+                local_folder += '/'.join(lzf.split('/')[:-1])
         print(f'Folder: {local_folder}')
         print('Collated')
         print('Verifying files...')
         files = [f for _,_,files in os.walk(local_folder) for f in files]
         print(files)
         print(logged_zipped_files)
-        if all([f in files for f in logged_zipped_files]):
+        if all([f in files for f in logged_zipped_files]) and len(files) == len(logged_zipped_files):
             print('All files uploaded')
         
     else:
@@ -133,7 +133,7 @@ for folder_row in df.iterrows():
         files = [f for _,_,files in os.walk(local_folder) for f in files]
         print(files)
         print(logged_files)
-        if all([f in files for f in logged_files]):
+        if all([f in files for f in logged_files]) and len(files) == len(logged_files):
             print('All files uploaded')
 
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -94,10 +94,6 @@ df.to_csv('test.csv', index=False)
 # print(len(uploaded_dirs))
 j=0
 for folder_row in df.iterrows():
-    print(f"local_folder: {folder_row[1]['LOCAL_FOLDER']}")
-    print(f"local_filename: {folder_row[1]['LOCAL_FILENAME']}")
-    print(f"zip_contents: {folder_row[1]['ZIP_CONTENTS']}")
-
     logged_files = folder_row[1]['LOCAL_FILENAME'].split(',')
     logged_zipped_files = folder_row[1]['ZIP_CONTENTS'].split(',')
     logged_zipped_files = [szf.split('/')[-1] for szf in logged_zipped_files]
@@ -115,6 +111,10 @@ for folder_row in df.iterrows():
         raise ValueError('Non-zip file with zip contents')
     elif logged_files[0].endswith('.zip') == False and logged_zipped_files[0] == '':
         collated = False
+
+    print(f"local_folder: {local_folder}")
+    print(f"logged_files: {logged_files}")
+    print(f"logged_zipped_files: {logged_zipped_files}")
     
     if collated:
         print(f'Folder: {local_folder}')

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -105,6 +105,10 @@ for folder_row in df.iterrows():
     collated = False
     if logged_files[0].endswith('.zip') and logged_zipped_files[0] != '':
         collated = True
+        for i, lzf in enumerate(logged_zipped_files):
+            if '/' in lzf:
+                logged_zipped_files[i] = lzf.split('/')[-1]
+                local_folder += '/'.join(lzf.split('/')[:-1])
     elif logged_files[0].endswith('.zip') and logged_zipped_files[0] == '':
         raise ValueError('Zip file with no contents')
     elif logged_files[0].endswith('.zip') == False and logged_zipped_files[0] != '':

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -1,3 +1,6 @@
+# Script to generate an exclude list for use with lsst-backup.py
+# Use with caution, this script verifies the existence of files reported in an upload in the local filesystem - it does not verify their existence on the remote server.
+
 import pandas as pd
 import os
 import sys

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -56,6 +56,7 @@ for folder_row in df.iterrows():
             if '/' in lzf:
                 lzf_list = lzf.split('/')
                 logged_zipped_files[i] = lzf_list[-1]
+                # need different subfolder extensions and to veirfy at subfolder level
         #         extend_path = '/' + '/'.join(lzf_list[:-1])
         # local_folder += extend_path
         print(f'Folder: {local_folder}')

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -123,7 +123,7 @@ for folder_row in df.iterrows():
         print(f'Folder: {local_folder}')
         print('Not collated')
         print('Verifying files...')
-        files = [os.path.join(local_folder, f) for _,_,files in os.path.walk(local_folder) for f in files]
+        files = [os.path.join(local_folder, f) for _,_,files in os.walk(local_folder) for f in files]
         print(files)
         print(logged_files)
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -72,7 +72,7 @@ df = df.drop(['LOCAL_PATH'], axis=1)
 
 print(df.head())
 print(df.tail())
-print(df.groupby('LOCAL_FOLDER').transform(lambda x: ','.join(str(x))))
+print(df.groupby('LOCAL_FOLDER').apply(','.join))
 exit()
 # print(len(df))
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -72,7 +72,7 @@ df = df.drop(['LOCAL_PATH'], axis=1)
 
 print(df.head())
 print(df.tail())
-print(df.groupby('LOCAL_FOLDER').transform(lambda x: ','.join(str(x))).drop_duplicates())
+print(df.groupby('LOCAL_FOLDER').transform(lambda x: ','.join(str(x))))
 exit()
 # print(len(df))
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -91,16 +91,20 @@ for folder_row in df.iterrows():
             else:
                 print('Unverified')
         else:
+            total_files_len = 0
+            verified_content = 0
             for lf in local_folders:
                 print(f'Verifying {lf}')
                 files = [f for _,_,files in os.walk(lf) for f in files]
                 print('files',files)
                 print('logged_zipped_files',logged_zipped_files)
-                if all([f in files for f in logged_zipped_files]) and len(files) == len(logged_zipped_files):
-                    print('Verified')
-                    exclude_list.append(lf)
-                else:
-                    print('Unverified')
+                total_files_len += len(files)
+                if all([f in files for f in logged_zipped_files]):
+                    verified_content += 1
+            if verified_content == len(local_folders) and total_files_len == len(logged_zipped_files):
+                print('Verified')
+                exclude_list.append(lf)
+               
         
         
     else:

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -27,7 +27,7 @@ def list_all_uploaded_leaf_dirs(df,local_folder):
 
 def verify_zipped_dirs(zipped_dirs_df):
     unique_zipped_dirs = zipped_dirs_df['BASE_PATH'].unique()
-    print(len(unique_zipped_dirs))
+    print(unique_zipped_dirs)
     verified_zipped = []
     for u_z_d in unique_zipped_dirs:
         these_zipped_dirs = zipped_dirs_df.loc[zipped_dirs_df['BASE_PATH'] == u_z_d]

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -56,6 +56,8 @@ dtypes = {'LOCAL_FOLDER': 'str', 'LOCAL_PATH': 'str', 'FILE_SIZE': 'float', 'BUC
 df = dd.read_csv(csv_file, dtype=dtypes).drop(['FILE_SIZE','BUCKET_NAME','DESTINATION_KEY','CHECKSUM'], axis=1).compute()
 
 for row in df.iterrows():
+    print(row[1]['LOCAL_PATH'])
+    print(row[1]['LOCAL_FOLDER'])
     if row[1]['LOCAL_PATH'].startswith(row[1]['LOCAL_FOLDER']):
         df.loc[row[1],'LOCAL_PATH'] = row[1]['LOCAL_PATH'][len(row[1]['LOCAL_FOLDER']):]
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -66,7 +66,7 @@ for row in df.iterrows():
         local_fns.append(row[1]['LOCAL_PATH'])
 df['LOCAL_FILENAME'] = local_fns
 df = df.drop(['LOCAL_PATH'], axis=1)
-df[df['ZIP_CONTENTS'].isna()] = ''
+df.loc[df['ZIP_CONTENTS'].isna(), 'ZIP_CONTENTS'] = ''
 
 
 

--- a/csd3-side/scripts/gen_exclude_list.py
+++ b/csd3-side/scripts/gen_exclude_list.py
@@ -56,7 +56,7 @@ dtypes = {'LOCAL_FOLDER': 'str', 'LOCAL_PATH': 'str', 'FILE_SIZE': 'float', 'BUC
 df = dd.read_csv(csv_file, dtype=dtypes).drop(['FILE_SIZE','BUCKET_NAME','DESTINATION_KEY','CHECKSUM'], axis=1).compute()
 
 for row in df.iterrows():
-    if row['LOCAL_PATH'].startswith(row['LOCAL_FOLDER']):
+    if row[1]['LOCAL_PATH'].startswith(row[1]['LOCAL_FOLDER']):
         df.loc[row[1],'LOCAL_PATH'] = row[1]['LOCAL_PATH'][len(row[1]['LOCAL_FOLDER']):]
 
 


### PR DESCRIPTION
Added an exclude list generator, which verifies an upload log with the local filesystem and advises on local folder to ignore when restarting a backup job. Use with caution - no verification of files on the remote server is performed - it is assumed if the file is named in the upload log then it is on the remote server (this is reasonable due to internal check by lsst-backup.py, but doesn't account for any other process that has deleted remote files).