### PR TITLE
continue on parent_folder == local_dir

### DIFF
--- a/csd3-side/scripts/lsst-backup.py
+++ b/csd3-side/scripts/lsst-backup.py
@@ -663,6 +663,8 @@ def process_files(s3_host, access_key, secret_key, bucket_name, current_objects,
         # print(to_collate)
         for zip_tuple in to_collate.items():
             parent_folder = zip_tuple[0]
+            if parent_folder == local_dir:
+                continue
             folders = zip_tuple[1]['folders']
             folder_files = zip_tuple[1]['folder_files']
             num_files = sum([len(ff) for ff in folder_files])


### PR DESCRIPTION
Skipping these for now so zips are not overwriten.